### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/mt-krainski/omni-platform/security/code-scanning/5](https://github.com/mt-krainski/omni-platform/security/code-scanning/5)

To fix this issue, the workflow file .github/workflows/ci.yml should include an explicit `permissions` block specifying the lowest privilege necessary for the workflow’s jobs. By inspecting the snippet, there's no evidence here that any of the jobs need write permissions to repository contents, pull requests, or other repository resources — they appear to simply run sub-workflows or pipelines for dependencies, linting, building, testing, and e2e tests. Therefore, the most conservative initial fix would be to set:

```yaml
permissions:
  contents: read
```

at the top-level of the workflow (immediately after the `name:`/`on:` block), ensuring all jobs are limited to read-only access to contents by default. If any invoked reusable workflow (the `uses:`-referenced subworkflows) requires higher permission, that can be overridden in those subworkflow files or on a per-job basis. The fix: insert the `permissions:` block directly after the `name: CI` line (before `on:` or after `on:` — both are valid placements according to GitHub Actions documentation).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
